### PR TITLE
Port template to .NET 9 and update to TShock version 6

### DIFF
--- a/PluginTemplate/PluginTemplate.csproj
+++ b/PluginTemplate/PluginTemplate.csproj
@@ -1,11 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
     <ItemGroup>
-      <PackageReference Include="TShock" Version="5.*" />
+      <PackageReference Include="TShock" Version="6.*" />
     </ItemGroup>
 </Project>

--- a/PluginTemplate/Properties/AssemblyInfo.cs
+++ b/PluginTemplate/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("PluginTemplate")]
-[assembly: AssemblyCopyright("Copyright © 2023")]
+[assembly: AssemblyCopyright("Copyright © 2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository acts as a baseline plugin to allow you to quickly and easily cre
 
 # Plugin Development
 
-For more information on TShock plugin development feel free to visit the [TShock repository](https://github.com/Pryaxis/TShock), the [TShock documentation](https://ikebukuro.tshock.co), the [TShock ReadMe](https://tshock.readme.io/docs/) or the official [TShock Discord](https://discord.com/invite/Cav9nYX).
+For more information on TShock plugin development feel free to visit the [TShock repository](https://github.com/Pryaxis/TShock), the [TShock documentation](https://github.com/Pryaxis/TShock/wiki), the [TShock ReadMe](https://tshock.readme.io/docs/) or the official [TShock Discord](https://discord.com/invite/Cav9nYX).


### PR DESCRIPTION
Updated target framework to .NET 9 and TShock package reference to version 6. I recreated and compiled the server hooks example with this template, and had no noticeable issues.

I also updated the documentation link in the readme to go directly to the github wiki instead of redirecting, this may not be needed.
I kept the readme wiki link despite it being heavily outdated since the TShock wiki link doesn't have a developer docs section (that I have noticed).

This is my first time making a contribution to a large project like TShock, and my first time working with .NET. I would appreciate any feedback if you have any <3